### PR TITLE
[BOJ] 3055 탈출 | 구현

### DIFF
--- a/오주영/Week4/BOJ_3055_탈출(미해결).py
+++ b/오주영/Week4/BOJ_3055_탈출(미해결).py
@@ -1,0 +1,71 @@
+import sys
+
+input=sys.stdin.readline
+
+rc=list(map(int,input().split()))
+
+field=[input().strip() for i in range(rc[0])]
+fstr=''
+for i in field:
+    fstr+=i    
+home=divmod(fstr.find('D'),rc[1])
+start=divmod(fstr.find('S'),rc[1])    
+    
+def findAll(str,a)->list:   #a의 모든 초기 위치의 리스트를 반환
+    num_a=str.count(a)
+    if num_a!=-1:
+        init_a=[fstr.find(a) for i in range(num_a)]
+        return init_a
+  
+
+def cordAll(a=list,Col=int)->list:
+    return [divmod(i,Col) for i in a]
+
+def adj(dict,tuple,t):
+    u=(tuple[0],tuple[1]+1)
+    d=(tuple[0],tuple[1]-1)
+    r=(tuple[0]+1,tuple[1])
+    l=(tuple[0]-1,tuple[1])
+    
+    case=list(filter(lambda i: dict.get(i,[100])[0]=='.' or dict.get(i,[100])[0]=='S',[u,d,r,l]))
+   
+    # print('case',case,t)
+    
+    for i in case:    
+        dict[i]=('*',t+1)      #어차피 field를 따로 쓰기 때문에 되돌아가기 방지로 값도 변경.
+        # print(i,dict[i],t)
+
+        if t<=dict[i][1]:
+            adj(dict,i,t+1)
+    # print(dict)
+            
+def ust(dict,tuple,t):
+    u=(tuple[0],tuple[1]+1)
+    d=(tuple[0],tuple[1]-1)
+    r=(tuple[0]+1,tuple[1])
+    l=(tuple[0]-1,tuple[1])
+    
+    case=list(filter(lambda i: dict.get(i,[100])[0]=='.' or dict.get(i,[100])[0]=='D',[u,d,r,l]))
+   
+    # print('case',case)
+    
+    for i in case:    
+        dict[i]=('S',t+1)      #어차피 field를 따로 쓰기 때문에 되돌아가기 방지로 값도 변경.
+        print(i,dict[i],t)
+    for i in case:
+        if t<=dict[i][1]:
+            adj(dict,i,t+1)
+    
+
+
+
+pw=findAll(fstr,'*')
+cord_pw=cordAll(pw,rc[1])  
+cart={divmod(i,rc[1]):[fstr[i],0] for i in range(rc[0]*rc[1])} 
+cart_w={}
+for i in cord_pw:
+    cart_w[i]={divmod(i,rc[1]):[fstr[i],0] for i in range(rc[0]*rc[1])}
+for cord in cord_pw:
+    adj(cart_w[i],cord,0)
+# adj
+print(cart_w)


### PR DESCRIPTION
[BOJ] 3055 탈출
난이도 : 골드4
알고리즘 유형 : 구현
내용 : 
초기 위치 파악.
R,C 다음의 입력을 하나의 문자열로 만들어준 후 각 요소의 인덱스를 (x,y)형태로 변환 #좌표 <\n> 좌표를 키로 하는 딕셔너리 생성| value는 [요소,0] 형태. #0은 초기 시간 t=0의 의미, 딕셔너리의 개수는 *의 개수+1<\n> 인접한 네 방향은 x+-1, y+-1 임을 이용하여<\n>
case=list(filter(lambda i: dict.get(i,[100])[0]=='.' or dict.get(i,[100])[0]=='D',[u,d,r,l])) <\n>
과 같은 방식으로 필터링함. #이동 가능 구역 <\n>
이동 가능 구역의 value를 (이동하는 요소,t+1)로 변경.<\n>
->재귀호출로 case==[] 일 때까지 반복수행 ''''''''' 여기서 막혔습니다.'''''''''<\n> 딕셔너리[1][1]이 더 낮은 쪽으로 *의 value 병합.<\n>
S의 각 이동에 대해 S의 t>=*의 t 이면 해당 이동 불가.<\n>
S의 case가 []인 동안 D의 좌표에 도달하지 못하면  KAKTUS