### PR TITLE
오주영 / 5월 2주차 / 3문제

### DIFF
--- a/오주영/Week6/3문제/BOJ_14500_테트로미노.py
+++ b/오주영/Week6/3문제/BOJ_14500_테트로미노.py
@@ -1,0 +1,62 @@
+import sys, heapq
+input=sys.stdin.readline
+
+x,y=tuple(map(int,input().split()))
+field_0=[list(map(int,sys.stdin.readline().split())) for _ in range(x)]   #원본 공간 x,y
+field_1=list(map(list,zip(*field_0)))  # 행 열 반전 y,x
+field_2=[field_1[i][-1::-1] for i in range(y)]  # 좌 우 반전 y,x
+field_3=list(map(list,zip(*field_2)))  # 행 열 반전 x,y
+field_4=[field_3[i][-1::-1] for i in range(x)]  # 좌 우 반전 x,y
+field_5=list(map(list,zip(*field_4)))  # 행 열 반전 y,x
+field_6=[field_5[i][-1::-1] for i in range(y)]  # 좌 우 반전 y,x
+field_7=list(map(list,zip(*field_6)))  # 행 열 반전 x,y
+# fieldset=(field_0,field_1,field_2,field_3,field_4,field_5,field_6,field_7)
+
+heap=[]
+# def blo(i,j):
+#     return ((i,j),(i+1,j),(i,j+1),(i+1,j+1))
+# def bli(i,j):
+    
+
+# def peak(bl_type,field):
+    
+
+for i in range(x-1):    #O블럭
+    for j in range(y-1):
+        blo=field_0[i][j]+field_0[i+1][j]+field_0[i][j+1]+field_0[i+1][j+1]
+        heapq.heappush(heap,-blo)
+
+for i in range(x):      #I블럭
+    for j in range(y-3):
+        bli=field_0[i][j]+field_0[i][j+1]+field_0[i][j+2]+field_0[i][j+3]
+        heapq.heappush(heap,-bli)       
+for i in range(y):      #I블럭
+    for j in range(x-3):        
+        bli=field_1[i][j]+field_1[i][j+1]+field_1[i][j+2]+field_1[i][j+3]
+        heapq.heappush(heap,-bli)
+        
+for i in range(x-1):    #S,T,7블럭
+    for j in range(y-2):
+        for fi in (field_0,field_3):
+            bls=fi[i][j]+fi[i][j+1]+fi[i+1][j+1]+fi[i+1][j+2]
+            heapq.heappush(heap,-bls)
+        for fi in (field_0,field_3,field_4,field_7):
+            blt=fi[i][j]+fi[i][j+1]+fi[i][j+2]+fi[i+1][j+1]
+            bl7=fi[i][j]+fi[i][j+1]+fi[i][j+2]+fi[i+1][j]
+            heapq.heappush(heap,-blt)
+            heapq.heappush(heap,-bl7)    
+            
+for i in range(y-1):    #S,T,7블럭
+    for j in range(x-2):
+        for fi in (field_1,field_2):
+            bls=fi[i][j]+fi[i][j+1]+fi[i+1][j+1]+fi[i+1][j+2]
+            heapq.heappush(heap,-bls)
+        for fi in (field_1,field_2,field_5,field_6):
+            blt=fi[i][j]+fi[i][j+1]+fi[i][j+2]+fi[i+1][j+1]
+            bl7=fi[i][j]+fi[i][j+1]+fi[i][j+2]+fi[i+1][j]
+            heapq.heappush(heap,-blt)
+            heapq.heappush(heap,-bl7)
+         
+print(-heapq.heappop(heap))
+
+

--- a/오주영/Week6/3문제/BOJ_14501_퇴사.py
+++ b/오주영/Week6/3문제/BOJ_14501_퇴사.py
@@ -1,0 +1,13 @@
+import sys
+
+input=sys.stdin.readline
+
+N=int(input())
+gain=[0 for _ in range(N+1)]    
+table=[tuple(map(int,input().split())) for _ in range(N)]
+
+for d,l in enumerate(table):
+    for i in range(d+l[0],N+1):
+        if gain[i] < gain[d]+l[1]:
+            gain[i] = gain[d]+l[1]
+print(gain[-1])

--- a/오주영/Week6/3문제/BOJ_2615_오목.py
+++ b/오주영/Week6/3문제/BOJ_2615_오목.py
@@ -1,0 +1,62 @@
+import sys
+
+def find_c(list):
+    for i,line in enumerate(list):
+        # if line.find('11111') != line.find('22222'):    #둘 다 오목인 경우 제외 //이거도 필요 없었다.
+            if line.find('11111')!=-1:
+                if line.find('111111')==-1:         #육목 제외
+                    return (1,i,line.find('11111'))
+            if line.find('22222')!=-1:
+                if line.find('222222')==-1:
+                    return (2,i,line.find('22222'))
+                
+'''
+# 25%에서 오답
+
+# 문제점 발견 : 같은 라인에 6목과 5목이 동시에 있는 경우를 무시한다.
+# 그런데 이 탐색방법이 안되면  문자열로 한 의미가 없다ㅠㅠ
+
+# re 모듈을 활용해보자
+
+인줄 알았는데 그냥 비겼을 때 0 출력을 못봐서 오답이었다. 삽질..
+'''
+
+field_hori=[sys.stdin.readline().rstrip().replace(' ','') for _ in range(19)]   #행 문자열
+field_valt=list(map(''.join,zip(*field_hori)))  # 열 문자열
+field_diag=[]   #대각 문자열
+
+for j in range(19):
+    diag1=diag2=diag3=diag4=''
+    for i in range(19):
+        if i+j<19:
+            diag1+=field_hori[i][i+j]   #우하향 대각선, 1행 출발
+            diag2+=field_hori[i+j][i]    #우하향 대각선, 1열 출발
+            diag3+=field_hori[18-i][i+j]   #우상향 대각선, 19행 출발
+            diag4+=field_hori[18-i-j][i]   #우상향 대각선, 1열 출발
+            
+    field_diag+=[diag1,diag2,diag3,diag4]
+    
+hori=find_c(field_hori)
+valt=find_c(field_valt)
+diag=find_c(field_diag)
+
+if hori:
+    print(hori[0])
+    print(hori[1]+1,hori[2]+1)
+
+elif valt:
+    print(valt[0])
+    print(valt[2]+1,valt[1]+1)
+    
+elif diag:
+    print(diag[0])
+    a=divmod(diag[1],4)
+    if a[1]==0:         #나머지에 따라 [i][i+j] | [i+j][i] | [18-i][i+j] | [18-i-j][i]
+        print(diag[2]+1,diag[2]+a[0]+1)
+    if a[1]==1:
+        print(diag[2]+a[0]+1,diag[2]+1)
+    if a[1]==2:
+        print(19-diag[2],diag[2]+a[0]+1)
+    if a[1]==3:
+        print(19-diag[2]-+a[0],diag[2]+1)
+else: print(0)


### PR DESCRIPTION
[BOJ] 2615 오목
난이도 : 실버1
알고리즘 유형 : 구현, 브루트보스
내용 : 
- 1이 있는 점들의 좌표, 2가 있는 점들의 좌표를 구한 후 탐색하려 함.  좌표를 구했으나 문자열 메서드를 활용하면 좋을 것 같아서 다음 접근으로 이동
- 행의 문자열 리스트, 열의 문자열 리스트, 대각 성분의 문자열 리스트를 구해서, 각 리스트에 대해 연속된 1이 5개이고 6개가 아닌 문자열의 왼쪽 첫번째 시작점의 좌표를 반환하게 구현. 이후 알았지만 승부가 결정되지 않았을 때 '0'을 출력하는 걸 빼먹어서 다음 접근으로 이동
- 한 성분에 육목과 오목이 같이 있는 경우에 오목을 잡아낼 수 없음을 발견. re 모듈을 통해 성분 안의 5개 이상 연속의 시작점을 집합으로 묶고, 6개 이상 연속의 시작점의 집합을 빼줬다. (같은 돌 오목이 2개 이상이면 오류가 있을 수 있으나 규칙 상 불가 하므로 배제했다 //동시에 오목인 경우 비기는 조건식을 적용했는데 오류가 있어 이 접근은 제출하지 않았다.
- 결과적으로 두 번째 접근에 승자가 없을 시 '0' 출력 적용으로 통과했으나 가능한 반례가 찜찜하다.

[BOJ] 14500 테트로미노
난이도 : 골드4
알고리즘 유형 : 구현, 브루트보스
내용 : 
- 도형을 회전, 대칭시키는 대신 회전, 대칭된 공간을 미리 만들어둔다.(가로 세로 길이 변화를 신경쓰기 싫어서..)
- 각 공간에 도형이 점유하는 좌표의 성분 합을 최대힙에 넣는다.
- 구현은 쉬웠는데 간소화할 부분이 많이 보인다.

[BOJ] 14501 퇴사
난이도 : 실버3
알고리즘 유형 : 다이나믹 프로그래밍, 브루트보스
내용 : (내용 없음)
